### PR TITLE
Add group member resource

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_project_hook": resourceGitlabProjectHook(),
 			"gitlab_deploy_key":   resourceGitlabDeployKey(),
 			"gitlab_user":         resourceGitlabUser(),
+			"gitlab_group_member": resourceGitlabGroupMember(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/gitlab/resource_gitlab_group_member.go
+++ b/gitlab/resource_gitlab_group_member.go
@@ -68,28 +68,28 @@ func resourceGitlabGroupMember() *schema.Resource {
 func resourceGitlabGroupMemberCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	group_id := d.Get("group_id").(string)
-	user_id := d.Get("user_id").(int)
-	access_level_id := accessLevelID[strings.ToLower(d.Get("access_level").(string))]
+	groupID := d.Get("group_id").(string)
+	userID := d.Get("user_id").(int)
+	accessLevelID := accessLevelID[strings.ToLower(d.Get("access_level").(string))]
 
 	options := &gitlab.AddGroupMemberOptions{
-		UserID:      &user_id,
-		AccessLevel: &access_level_id,
+		UserID:      &userID,
+		AccessLevel: &accessLevelID,
 	}
 
 	if exp, ok := d.GetOk("expires_at"); ok {
-		expires_at := exp.(string)
-		options.ExpiresAt = &expires_at
+		expiresAt := exp.(string)
+		options.ExpiresAt = &expiresAt
 	}
 
-	log.Printf("[DEBUG] create gitlab group member %d in %s", user_id, group_id)
+	log.Printf("[DEBUG] create gitlab group member %d in %s", userID, groupID)
 
-	group_member, _, err := client.GroupMembers.AddGroupMember(group_id, options)
+	groupMember, _, err := client.GroupMembers.AddGroupMember(groupID, options)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("%d", group_member.ID))
+	d.SetId(fmt.Sprintf("%d", groupMember.ID))
 
 	return resourceGitlabGroupMemberRead(d, meta)
 }
@@ -98,32 +98,32 @@ func resourceGitlabGroupMemberRead(d *schema.ResourceData, meta interface{}) err
 	client := meta.(*gitlab.Client)
 	log.Printf("[DEBUG] read gitlab group member %s", d.Id())
 
-	group_id := d.Get("group_id").(string)
-	user_id := d.Get("user_id").(int)
+	groupID := d.Get("group_id").(string)
+	userID := d.Get("user_id").(int)
 
-	group_member, resp, err := client.GroupMembers.GetGroupMember(group_id, user_id)
+	groupMember, resp, err := client.GroupMembers.GetGroupMember(groupID, userID)
 	if err != nil {
 		if resp.StatusCode == 404 {
-			log.Printf("[WARN] removing group member %s in %s from state because it no longer exists in gitlab", d.Id(), group_id)
+			log.Printf("[WARN] removing group member %s in %s from state because it no longer exists in gitlab", d.Id(), groupID)
 			d.SetId("")
 			return nil
 		}
 		return err
 	}
 
-	d.Set("access_level", accessLevel[group_member.AccessLevel])
-	if group_member.ExpiresAt != nil {
-		d.Set("expires_at", group_member.ExpiresAt.String())
+	d.Set("access_level", accessLevel[groupMember.AccessLevel])
+	if groupMember.ExpiresAt != nil {
+		d.Set("expires_at", groupMember.ExpiresAt.String())
 	}
-	if group_member.CreatedAt != nil {
-		d.Set("created_at", group_member.CreatedAt.String())
+	if groupMember.CreatedAt != nil {
+		d.Set("created_at", groupMember.CreatedAt.String())
 	}
-	if group_member.Email != "" {
-		d.Set("email", group_member.Email)
+	if groupMember.Email != "" {
+		d.Set("email", groupMember.Email)
 	}
-	d.Set("username", group_member.Username)
-	d.Set("name", group_member.Name)
-	d.Set("state", group_member.State)
+	d.Set("username", groupMember.Username)
+	d.Set("name", groupMember.Name)
+	d.Set("state", groupMember.State)
 
 	return nil
 }
@@ -131,22 +131,22 @@ func resourceGitlabGroupMemberRead(d *schema.ResourceData, meta interface{}) err
 func resourceGitlabGroupMemberUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	group_id := d.Get("group_id").(string)
-	user_id := d.Get("user_id").(int)
-	access_level_id := accessLevelID[strings.ToLower(d.Get("access_level").(string))]
+	groupID := d.Get("group_id").(string)
+	userID := d.Get("user_id").(int)
+	accessLevelID := accessLevelID[strings.ToLower(d.Get("access_level").(string))]
 
 	options := &gitlab.EditGroupMemberOptions{
-		AccessLevel: &access_level_id,
+		AccessLevel: &accessLevelID,
 	}
 
 	if exp, ok := d.GetOk("expires_at"); ok {
-		expires_at := exp.(string)
-		options.ExpiresAt = &expires_at
+		expiresAt := exp.(string)
+		options.ExpiresAt = &expiresAt
 	}
 
-	log.Printf("[DEBUG] update gitlab group member %s in %s", d.Id(), group_id)
+	log.Printf("[DEBUG] update gitlab group member %s in %s", d.Id(), groupID)
 
-	_, _, err := client.GroupMembers.EditGroupMember(group_id, user_id, options)
+	_, _, err := client.GroupMembers.EditGroupMember(groupID, userID, options)
 	if err != nil {
 		return err
 	}
@@ -157,12 +157,12 @@ func resourceGitlabGroupMemberUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceGitlabGroupMemberDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	group_id := d.Get("group_id").(string)
-	user_id := d.Get("user_id").(int)
+	groupID := d.Get("group_id").(string)
+	userID := d.Get("user_id").(int)
 
-	log.Printf("[DEBUG] delete gitlab group member %s from %s", d.Id(), group_id)
+	log.Printf("[DEBUG] delete gitlab group member %s from %s", d.Id(), groupID)
 
-	_, err := client.GroupMembers.RemoveGroupMember(group_id, user_id)
+	_, err := client.GroupMembers.RemoveGroupMember(groupID, userID)
 	if err != nil {
 		return err
 	}
@@ -175,17 +175,17 @@ func resourceGitlabGroupMemberDelete(d *schema.ResourceData, meta interface{}) e
 func resourceGitlabGroupMemberImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	// Parse ID to get both user_id and group_id - Must be in user_id/group_id format
 	ids := strings.Split(d.Id(), "/")
-	user_id, err := strconv.Atoi(ids[0])
+	userID, err := strconv.Atoi(ids[0])
 	if err != nil {
-		fmt.Errorf("[ERROR] coulnd't parse user_id during import: %v", err)
+		return nil, fmt.Errorf("[ERROR] coulnd't parse user_id during import: %v", err)
 	}
-	group_id := ids[1]
+	groupID := ids[1]
 
-	d.Set("group_id", group_id)
-	d.Set("user_id", user_id)
-	d.SetId(fmt.Sprintf("%d", user_id))
+	d.Set("group_id", groupID)
+	d.Set("user_id", userID)
+	d.SetId(fmt.Sprintf("%d", userID))
 
-	log.Printf("[DEBUG] import gitlab group member %d from %s", user_id, group_id)
+	log.Printf("[DEBUG] import gitlab group member %d from %s", userID, groupID)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/gitlab/resource_gitlab_group_member.go
+++ b/gitlab/resource_gitlab_group_member.go
@@ -65,14 +65,6 @@ func resourceGitlabGroupMember() *schema.Resource {
 	}
 }
 
-var accessLevel = map[gitlab.AccessLevelValue]string{
-	gitlab.GuestPermissions:     "guest",
-	gitlab.ReporterPermissions:  "reporter",
-	gitlab.DeveloperPermissions: "developer",
-	gitlab.MasterPermissions:    "master",
-	gitlab.OwnerPermission:      "owner",
-}
-
 func resourceGitlabGroupMemberCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
@@ -119,7 +111,7 @@ func resourceGitlabGroupMemberRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	d.Set("access_level", group_member.AccessLevel)
+	d.Set("access_level", accessLevel[group_member.AccessLevel])
 	if group_member.ExpiresAt != nil {
 		d.Set("expires_at", group_member.ExpiresAt.String())
 	}

--- a/gitlab/resource_gitlab_group_member.go
+++ b/gitlab/resource_gitlab_group_member.go
@@ -1,0 +1,181 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabGroupMember() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabGroupMemberCreate,
+		Read:   resourceGitlabGroupMemberRead,
+		Update: resourceGitlabGroupMemberUpdate,
+		Delete: resourceGitlabGroupMemberDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"access_level": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{"guest", "reporter", "developer", "master", "owner"}, true),
+			},
+			"expires_at": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// var accessLevelID = map[string]gitlab.AccessLevelValue{
+// 	"guest":     gitlab.GuestPermissions,
+// 	"reporter":  gitlab.ReporterPermissions,
+// 	"developer": gitlab.DeveloperPermissions,
+// 	"master":    gitlab.MasterPermissions,
+// 	"owner":     gitlab.OwnerPermission,
+// }
+
+func resourceGitlabGroupMemberCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	group_id := d.Get("group_id").(string)
+	user_id := d.Get("user_id").(int)
+	access_level_id := accessLevelID[strings.ToLower(d.Get("access_level").(string))]
+
+	options := &gitlab.AddGroupMemberOptions{
+		UserID:      &user_id,
+		AccessLevel: &access_level_id,
+	}
+
+	if exp, ok := d.GetOk("expires_at"); ok {
+		expires_at := exp.(string)
+		options.ExpiresAt = &expires_at
+	}
+
+	log.Printf("[DEBUG] create gitlab group member for %d in %s", user_id, group_id)
+
+	group_member, _, err := client.GroupMembers.AddGroupMember(group_id, options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%d", group_member.ID))
+
+	return resourceGitlabGroupMemberRead(d, meta)
+}
+
+func resourceGitlabGroupMemberRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	log.Printf("[DEBUG] read gitlab group member %s", d.Id())
+
+	group_id := d.Get("group_id").(string)
+	user_id := d.Get("user_id").(int)
+
+	group_member, resp, err := client.GroupMembers.GetGroupMember(group_id, user_id)
+	if err != nil {
+		if resp.StatusCode == 404 {
+			log.Printf("[WARN] removing group member %s for %s from state because it no longer exists in gitlab", d.Id(), group_id)
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	// TODO: int to string
+	d.Set("access_level", group_member.AccessLevel)
+	if group_member.ExpiresAt != nil {
+		d.Set("expires_at", group_member.ExpiresAt.String())
+	}
+	if group_member.CreatedAt != nil {
+		d.Set("created_at", group_member.CreatedAt.String())
+	}
+	if group_member.Email != "" {
+		d.Set("email", group_member.Email)
+	}
+	d.Set("username", group_member.Username)
+	d.Set("name", group_member.Name)
+	d.Set("state", group_member.State)
+
+	return nil
+}
+
+func resourceGitlabGroupMemberUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	group_id := d.Get("group_id").(string)
+	user_id := d.Get("user_id").(int)
+	access_level_id := accessLevelID[strings.ToLower(d.Get("access_level").(string))]
+
+	options := &gitlab.EditGroupMemberOptions{
+		AccessLevel: &access_level_id,
+	}
+
+	if exp, ok := d.GetOk("expires_at"); ok {
+		expires_at := exp.(string)
+		options.ExpiresAt = &expires_at
+	}
+
+	log.Printf("[DEBUG] update gitlab group member %s for %s", d.Id(), group_id)
+
+	_, _, err := client.GroupMembers.EditGroupMember(group_id, user_id, options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitlabGroupMemberRead(d, meta)
+}
+
+func resourceGitlabGroupMemberDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	group_id := d.Get("group_id").(string)
+	user_id := d.Get("user_id").(int)
+
+	log.Printf("[DEBUG] delete gitlab group member %s from %s", d.Id(), group_id)
+
+	_, err := client.GroupMembers.RemoveGroupMember(group_id, user_id)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/gitlab/resource_gitlab_group_member_test.go
+++ b/gitlab/resource_gitlab_group_member_test.go
@@ -46,7 +46,7 @@ func TestAccGitlabGroupMember_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckGitlabGroupMemberExists(n string, group_member *gitlab.GroupMember) resource.TestCheckFunc {
+func testAccCheckGitlabGroupMemberExists(n string, groupMember *gitlab.GroupMember) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		conn := testAccProvider.Meta().(*gitlab.Client)
@@ -70,7 +70,7 @@ func testAccCheckGitlabGroupMemberExists(n string, group_member *gitlab.GroupMem
 			return err
 		}
 
-		*group_member = *gotGroupMember
+		*groupMember = *gotGroupMember
 		return nil
 	}
 }
@@ -80,19 +80,19 @@ type testAccGitlabGroupMemberExpectedAttributes struct {
 	ExpiresAt   string
 }
 
-func testAccCheckGitlabGroupMemberAttributes(group_member *gitlab.GroupMember, want *testAccGitlabGroupMemberExpectedAttributes) resource.TestCheckFunc {
+func testAccCheckGitlabGroupMemberAttributes(groupMember *gitlab.GroupMember, want *testAccGitlabGroupMemberExpectedAttributes) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		access_level_id, ok := accessLevel[group_member.AccessLevel]
+		accessLevelID, ok := accessLevel[groupMember.AccessLevel]
 		if !ok {
-			return fmt.Errorf("Invalid access level '%s'", access_level_id)
+			return fmt.Errorf("Invalid access level '%s'", accessLevelID)
 		}
-		if access_level_id != want.AccessLevel {
-			return fmt.Errorf("got access level %s; want %s", access_level_id, want.AccessLevel)
+		if accessLevelID != want.AccessLevel {
+			return fmt.Errorf("got access level %s; want %s", accessLevelID, want.AccessLevel)
 		}
 
-		if (group_member.ExpiresAt != nil) && (group_member.ExpiresAt.String() != want.ExpiresAt) {
-			return fmt.Errorf("got expires at %q; want %q", group_member.ExpiresAt, want.ExpiresAt)
+		if (groupMember.ExpiresAt != nil) && (groupMember.ExpiresAt.String() != want.ExpiresAt) {
+			return fmt.Errorf("got expires at %q; want %q", groupMember.ExpiresAt, want.ExpiresAt)
 		}
 
 		return nil
@@ -114,7 +114,7 @@ func testAccCheckGitlabGroupMemberDestroy(s *terraform.State) error {
 		gotMembership, resp, err := conn.GroupMembers.GetGroupMember(groupID, userIDI)
 		if err != nil {
 			if gotMembership != nil && fmt.Sprintf("%d", gotMembership.AccessLevel) == rs.Primary.Attributes["access_level"] {
-				return fmt.Errorf("Group still has member.")
+				return fmt.Errorf("group still has member")
 			}
 			return nil
 		}

--- a/gitlab/resource_gitlab_group_member_test.go
+++ b/gitlab/resource_gitlab_group_member_test.go
@@ -19,35 +19,34 @@ func TestAccGitlabGroupMember_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGitlabGroupMemberDestroy,
 		Steps: []resource.TestStep{
-
-			// Assign member to the project as a developer
 			{
 				Config: testAccGitlabGroupMemberConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember), testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
-					access_level: fmt.Sprintf("developer"),
-				})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember),
+					testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
+						AccessLevel: fmt.Sprintf("developer"),
+					})),
 			},
-
-			// Update the group member to change the access level (use testAccGitlabGroupMemberUpdateConfig for Config)
 			{
 				Config: testAccGitlabGroupMemberUpdateConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember), testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
-					access_level: fmt.Sprintf("guest"),
-				})),
+				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember),
+					testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
+						AccessLevel: fmt.Sprintf("guest"),
+						ExpiresAt:   fmt.Sprintf("2099-01-01"),
+					})),
 			},
-
-			// Update the group member to change the access level back
 			{
 				Config: testAccGitlabGroupMemberConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember), testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
-					access_level: fmt.Sprintf("developer"),
-				})),
+				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember),
+					testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
+						AccessLevel: fmt.Sprintf("developer"),
+					})),
 			},
 		},
 	})
 }
 
-func testAccCheckGitlabGroupMemberExists(n string, membership *gitlab.GroupMember) resource.TestCheckFunc {
+func testAccCheckGitlabGroupMemberExists(n string, group_member *gitlab.GroupMember) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		conn := testAccProvider.Meta().(*gitlab.Client)
@@ -57,7 +56,7 @@ func testAccCheckGitlabGroupMemberExists(n string, membership *gitlab.GroupMembe
 
 		groupID := rs.Primary.Attributes["group_id"]
 		if groupID == "" {
-			return fmt.Errorf("No project ID is set")
+			return fmt.Errorf("No group ID is set")
 		}
 
 		userID := rs.Primary.Attributes["user_id"]
@@ -71,33 +70,31 @@ func testAccCheckGitlabGroupMemberExists(n string, membership *gitlab.GroupMembe
 			return err
 		}
 
-		*membership = *gotGroupMember
+		*group_member = *gotGroupMember
 		return nil
 	}
 }
 
 type testAccGitlabGroupMemberExpectedAttributes struct {
-	access_level string
+	AccessLevel string
+	ExpiresAt   string
 }
 
-// var accessLevel = map[gitlab.AccessLevelValue]string{
-// 	gitlab.GuestPermissions:     "guest",
-// 	gitlab.ReporterPermissions:  "reporter",
-// 	gitlab.DeveloperPermissions: "developer",
-// 	gitlab.MasterPermissions:    "master",
-// 	gitlab.OwnerPermission:      "owner",
-// }
-
-func testAccCheckGitlabGroupMemberAttributes(membership *gitlab.GroupMember, want *testAccGitlabGroupMemberExpectedAttributes) resource.TestCheckFunc {
+func testAccCheckGitlabGroupMemberAttributes(group_member *gitlab.GroupMember, want *testAccGitlabGroupMemberExpectedAttributes) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		access_level_id, ok := accessLevel[membership.AccessLevel]
+		access_level_id, ok := accessLevel[group_member.AccessLevel]
 		if !ok {
 			return fmt.Errorf("Invalid access level '%s'", access_level_id)
 		}
-		if access_level_id != want.access_level {
-			return fmt.Errorf("got access level %s; want %s", access_level_id, want.access_level)
+		if access_level_id != want.AccessLevel {
+			return fmt.Errorf("got access level %s; want %s", access_level_id, want.AccessLevel)
 		}
+
+		if (group_member.ExpiresAt != nil) && (group_member.ExpiresAt.String() != want.ExpiresAt) {
+			return fmt.Errorf("got expires at %q; want %q", group_member.ExpiresAt, want.ExpiresAt)
+		}
+
 		return nil
 	}
 }
@@ -113,12 +110,11 @@ func testAccCheckGitlabGroupMemberDestroy(s *terraform.State) error {
 		groupID := rs.Primary.Attributes["group_id"]
 		userID := rs.Primary.Attributes["user_id"]
 
-		// GetGroupMember needs int type for userID
 		userIDI, err := strconv.Atoi(userID)
 		gotMembership, resp, err := conn.GroupMembers.GetGroupMember(groupID, userIDI)
 		if err != nil {
 			if gotMembership != nil && fmt.Sprintf("%d", gotMembership.AccessLevel) == rs.Primary.Attributes["access_level"] {
-				return fmt.Errorf("Project still has member.")
+				return fmt.Errorf("Group still has member.")
 			}
 			return nil
 		}
@@ -132,45 +128,54 @@ func testAccCheckGitlabGroupMemberDestroy(s *terraform.State) error {
 }
 
 func testAccGitlabGroupMemberConfig(rInt int) string {
-	return fmt.Sprintf(`resource "gitlab_group_member" "foo" {
-group_id = "${gitlab_project.foo.id}"
-user_id = "${gitlab_user.test.id}"
-access_level = "developer"
+	return fmt.Sprintf(`
+resource "gitlab_group_member" "foo" {
+  group_id     = "${gitlab_group.foo.id}"
+  user_id      = "${gitlab_user.test.id}"
+  access_level = "developer"
 }
 
-resource "gitlab_project" "foo" {
-name = "foo%d"
-description = "Terraform acceptance tests"
-visibility_level ="public"
+resource "gitlab_group" "foo" {
+  name                   = "bar-name-%d"
+  path                   = "bar-path-%d"
+  description            = "Terraform acceptance tests - group member"
+  lfs_enabled            = false
+  request_access_enabled = true
+  visibility_level       = "public"
 }
 
 resource "gitlab_user" "test" {
-name = "foo%d"
-username = "listest%d"
-password = "test%dtt"
-email = "listest%d@ssss.com"
+  name     = "foo%d"
+  username = "listest%d"
+  password = "test%dtt"
+  email    = "listest%d@ssss.com"
 }
-`, rInt, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
 func testAccGitlabGroupMemberUpdateConfig(rInt int) string {
-	return fmt.Sprintf(`resource "gitlab_group_member" "foo" {
-group_id = "${gitlab_project.foo.id}"
-user_id = "${gitlab_user.test.id}"
-access_level = "guest"
+	return fmt.Sprintf(`
+resource "gitlab_group_member" "foo" {
+  group_id     = "${gitlab_group.foo.id}"
+  user_id      = "${gitlab_user.test.id}"
+  access_level = "guest"
+  expires_at   = "2099-01-01"
 }
 
-resource "gitlab_project" "foo" {
-name = "foo%d"
-description = "Terraform acceptance tests"
-visibility_level ="public"
+resource "gitlab_group" "foo" {
+  name                   = "bar-name-%d"
+  path                   = "bar-path-%d"
+  description            = "Terraform acceptance tests - group member"
+  lfs_enabled            = false
+  request_access_enabled = true
+  visibility_level       = "public"
 }
 
 resource "gitlab_user" "test" {
-name = "foo%d"
-username = "listest%d"
-password = "test%dtt"
-email = "listest%d@ssss.com"
+  name     = "foo%d"
+  username = "listest%d"
+  password = "test%dtt"
+  email    = "listest%d@ssss.com"
 }
-`, rInt, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt, rInt, rInt)
 }

--- a/gitlab/resource_gitlab_group_member_test.go
+++ b/gitlab/resource_gitlab_group_member_test.go
@@ -1,0 +1,176 @@
+package gitlab
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabGroupMember_basic(t *testing.T) {
+	var groupMember gitlab.GroupMember
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{PreCheck: func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabGroupMemberDestroy,
+		Steps: []resource.TestStep{
+
+			// Assign member to the project as a developer
+			{
+				Config: testAccGitlabGroupMemberConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember), testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
+					access_level: fmt.Sprintf("developer"),
+				})),
+			},
+
+			// Update the group member to change the access level (use testAccGitlabGroupMemberUpdateConfig for Config)
+			{
+				Config: testAccGitlabGroupMemberUpdateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember), testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
+					access_level: fmt.Sprintf("guest"),
+				})),
+			},
+
+			// Update the group member to change the access level back
+			{
+				Config: testAccGitlabGroupMemberConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMemberExists("gitlab_group_member.foo", &groupMember), testAccCheckGitlabGroupMemberAttributes(&groupMember, &testAccGitlabGroupMemberExpectedAttributes{
+					access_level: fmt.Sprintf("developer"),
+				})),
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabGroupMemberExists(n string, membership *gitlab.GroupMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		conn := testAccProvider.Meta().(*gitlab.Client)
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		groupID := rs.Primary.Attributes["group_id"]
+		if groupID == "" {
+			return fmt.Errorf("No project ID is set")
+		}
+
+		userID := rs.Primary.Attributes["user_id"]
+		id, _ := strconv.Atoi(userID)
+		if userID == "" {
+			return fmt.Errorf("No user id is set")
+		}
+
+		gotGroupMember, _, err := conn.GroupMembers.GetGroupMember(groupID, id)
+		if err != nil {
+			return err
+		}
+
+		*membership = *gotGroupMember
+		return nil
+	}
+}
+
+type testAccGitlabGroupMemberExpectedAttributes struct {
+	access_level string
+}
+
+// var accessLevel = map[gitlab.AccessLevelValue]string{
+// 	gitlab.GuestPermissions:     "guest",
+// 	gitlab.ReporterPermissions:  "reporter",
+// 	gitlab.DeveloperPermissions: "developer",
+// 	gitlab.MasterPermissions:    "master",
+// 	gitlab.OwnerPermission:      "owner",
+// }
+
+func testAccCheckGitlabGroupMemberAttributes(membership *gitlab.GroupMember, want *testAccGitlabGroupMemberExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		access_level_id, ok := accessLevel[membership.AccessLevel]
+		if !ok {
+			return fmt.Errorf("Invalid access level '%s'", access_level_id)
+		}
+		if access_level_id != want.access_level {
+			return fmt.Errorf("got access level %s; want %s", access_level_id, want.access_level)
+		}
+		return nil
+	}
+}
+
+func testAccCheckGitlabGroupMemberDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_group_member" {
+			continue
+		}
+
+		groupID := rs.Primary.Attributes["group_id"]
+		userID := rs.Primary.Attributes["user_id"]
+
+		// GetGroupMember needs int type for userID
+		userIDI, err := strconv.Atoi(userID)
+		gotMembership, resp, err := conn.GroupMembers.GetGroupMember(groupID, userIDI)
+		if err != nil {
+			if gotMembership != nil && fmt.Sprintf("%d", gotMembership.AccessLevel) == rs.Primary.Attributes["access_level"] {
+				return fmt.Errorf("Project still has member.")
+			}
+			return nil
+		}
+
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccGitlabGroupMemberConfig(rInt int) string {
+	return fmt.Sprintf(`resource "gitlab_group_member" "foo" {
+group_id = "${gitlab_project.foo.id}"
+user_id = "${gitlab_user.test.id}"
+access_level = "developer"
+}
+
+resource "gitlab_project" "foo" {
+name = "foo%d"
+description = "Terraform acceptance tests"
+visibility_level ="public"
+}
+
+resource "gitlab_user" "test" {
+name = "foo%d"
+username = "listest%d"
+password = "test%dtt"
+email = "listest%d@ssss.com"
+}
+`, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccGitlabGroupMemberUpdateConfig(rInt int) string {
+	return fmt.Sprintf(`resource "gitlab_group_member" "foo" {
+group_id = "${gitlab_project.foo.id}"
+user_id = "${gitlab_user.test.id}"
+access_level = "guest"
+}
+
+resource "gitlab_project" "foo" {
+name = "foo%d"
+description = "Terraform acceptance tests"
+visibility_level ="public"
+}
+
+resource "gitlab_user" "test" {
+name = "foo%d"
+username = "listest%d"
+password = "test%dtt"
+email = "listest%d@ssss.com"
+}
+`, rInt, rInt, rInt, rInt, rInt)
+}

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -7,6 +7,14 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
+var accessLevelID = map[string]gitlab.AccessLevelValue{
+	"guest":     gitlab.GuestPermissions,
+	"reporter":  gitlab.ReporterPermissions,
+	"developer": gitlab.DeveloperPermissions,
+	"master":    gitlab.MasterPermissions,
+	"owner":     gitlab.OwnerPermission,
+}
+
 // copied from ../github/util.go
 func validateValueFunc(values []string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (we []string, errors []error) {

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -15,6 +15,14 @@ var accessLevelID = map[string]gitlab.AccessLevelValue{
 	"owner":     gitlab.OwnerPermission,
 }
 
+var accessLevel = map[gitlab.AccessLevelValue]string{
+	gitlab.GuestPermissions:     "guest",
+	gitlab.ReporterPermissions:  "reporter",
+	gitlab.DeveloperPermissions: "developer",
+	gitlab.MasterPermissions:    "master",
+	gitlab.OwnerPermission:      "owner",
+}
+
 // copied from ../github/util.go
 func validateValueFunc(values []string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (we []string, errors []error) {


### PR DESCRIPTION
# Add group member resource
Allows to insert members in an existing group.

For imports, inserted id must follow the following format: _user_id/group_id_.
- [x] Merge #2 
- [x] Rebase on master