### PR TITLE
Add gitlab_users datasource

### DIFF
--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -1,0 +1,103 @@
+package gitlab
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func dataSourceGitlabUsers() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabUsersRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "all_users",
+			},
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_admin": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"can_create_group": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"can_create_project": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"projects_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGitlabUsersRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	users, _, err := client.Users.ListUsers(nil)
+	if err != nil {
+		return err
+	}
+
+	d.Set("users", flattenGitlabUsers(users))
+	d.SetId(d.Get("name").(string))
+
+	return nil
+}
+
+func flattenGitlabUsers(users []*gitlab.User) []interface{} {
+	usersList := []interface{}{}
+
+	for _, user := range users {
+		values := map[string]interface{}{
+			"username":           user.Username,
+			"email":              user.Email,
+			"name":               user.Name,
+			"is_admin":           user.IsAdmin,
+			"can_create_group":   user.CanCreateGroup,
+			"can_create_project": user.CanCreateProject,
+			"projects_limit":     user.ProjectsLimit,
+			"state":              user.State,
+		}
+
+		if user.CreatedAt != nil {
+			values["created_at"] = user.CreatedAt.String()
+		}
+
+		usersList = append(usersList, values)
+	}
+
+	return usersList
+}

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -215,7 +215,7 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 	optionsHash += ","
 	if data, ok := d.GetOk("identities_provider"); ok {
 		provider := data.(string)
-		// listUsersOptions.Provider = &provider
+		listUsersOptions.Provider = &provider
 		optionsHash += provider
 	}
 	optionsHash += ","
@@ -231,11 +231,11 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 	optionsHash += ","
 	if data, ok := d.GetOk("created_after"); ok {
 		createdAfter := data.(string)
-		// date, err := time.Parse("2006-01-02", createdAfter)
-		// if err != nil {
-		// 	return nil, 0, fmt.Errorf("created_after must be in yyyy-mm-dd format")
-		// }
-		// listUsersOptions.CreatedAfter = &date
+		date, err := time.Parse("2006-01-02", createdAfter)
+		if err != nil {
+			return nil, 0, fmt.Errorf("created_after must be in yyyy-mm-dd format")
+		}
+		listUsersOptions.CreatedAfter = &date
 		optionsHash += createdAfter
 	}
 

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -182,36 +182,43 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 		listUsersOptions.OrderBy = &orderBy
 		optionsHash += orderBy
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("sort"); ok {
 		sort := data.(string)
 		listUsersOptions.Sort = &sort
 		optionsHash += sort
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("search"); ok {
 		search := data.(string)
 		listUsersOptions.Search = &search
 		optionsHash += search
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("active"); ok {
 		active := data.(bool)
 		listUsersOptions.Active = &active
 		optionsHash += strconv.FormatBool(active)
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("blocked"); ok {
 		blocked := data.(bool)
 		listUsersOptions.Blocked = &blocked
 		optionsHash += strconv.FormatBool(blocked)
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("identities_extern_uid"); ok {
 		externalUID := data.(string)
 		listUsersOptions.ExternalUID = &externalUID
 		optionsHash += externalUID
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("identities_provider"); ok {
 		provider := data.(string)
 		// listUsersOptions.Provider = &provider
 		optionsHash += provider
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("created_before"); ok {
 		createdBefore := data.(string)
 		date, err := time.Parse("2006-01-02", createdBefore)
@@ -221,6 +228,7 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 		listUsersOptions.CreatedBefore = &date
 		optionsHash += createdBefore
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("created_after"); ok {
 		createdAfter := data.(string)
 		// date, err := time.Parse("2006-01-02", createdAfter)

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -1,6 +1,11 @@
 package gitlab
 
 import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -11,25 +16,62 @@ func dataSourceGitlabUsers() *schema.Resource {
 		Read: dataSourceGitlabUsersRead,
 
 		Schema: map[string]*schema.Schema{
-			"order_by": {
-				Type:     schema.TypeString,
+			"options": {
+				Type:     schema.TypeList,
 				Optional: true,
-				Default:  "id",
-				ValidateFunc: validation.StringInSlice([]string{"id", "name",
-					"username", "created_at"}, true),
-			},
-			"sort": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "desc",
-				ValidateFunc: validation.StringInSlice([]string{"desc", "asc"}, true),
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"order_by": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "id",
+							ValidateFunc: validation.StringInSlice([]string{"id", "name",
+								"username", "created_at"}, true),
+						},
+						"sort": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "desc",
+							ValidateFunc: validation.StringInSlice([]string{"desc", "asc"}, true),
+						},
+						"search": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"active": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"blocked": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"extern_uid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"provider": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"created_before": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"created_after": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 			"users": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
+						"user_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
@@ -73,6 +115,18 @@ func dataSourceGitlabUsers() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"extern_uid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"organization": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"two_factor_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -83,21 +137,20 @@ func dataSourceGitlabUsers() *schema.Resource {
 func dataSourceGitlabUsersRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	orderBy := d.Get("order_by").(string)
-	sort := d.Get("sort").(string)
-	listUsersOptions := &gitlab.ListUsersOptions{
-		OrderBy: &orderBy,
-		Sort:    &sort,
+	listUsersOptions, id, err := expandGitlabUsersOptions(d.Get("options").([]interface{}))
+	if err != nil {
+		return err
 	}
-
+	log.Printf("\n\n\nListOptions\n%v\n\n\n", listUsersOptions)
 	users, _, err := client.Users.ListUsers(listUsersOptions)
+	log.Printf("\n\n\nListUsers\n%v\n\n\n", users)
+
 	if err != nil {
 		return err
 	}
 
 	d.Set("users", flattenGitlabUsers(users))
-	id := "all_users_" + orderBy + "_" + sort
-	d.SetId(id)
+	d.SetId(fmt.Sprintf("%d", id))
 
 	return nil
 }
@@ -107,7 +160,7 @@ func flattenGitlabUsers(users []*gitlab.User) []interface{} {
 
 	for _, user := range users {
 		values := map[string]interface{}{
-			"id":                 user.ID,
+			"user_id":            user.ID,
 			"username":           user.Username,
 			"email":              user.Email,
 			"name":               user.Name,
@@ -117,14 +170,76 @@ func flattenGitlabUsers(users []*gitlab.User) []interface{} {
 			"projects_limit":     user.ProjectsLimit,
 			"state":              user.State,
 			"external":           user.External,
+			"extern_uid":         user.ExternUID,
+			"organization":       user.Organization,
+			"two_factor_enabled": user.TwoFactorEnabled,
 		}
 
 		if user.CreatedAt != nil {
-			values["created_at"] = user.CreatedAt.String()
+			values["created_at"] = user.CreatedAt
 		}
 
 		usersList = append(usersList, values)
 	}
 
 	return usersList
+}
+
+func expandGitlabUsersOptions(d []interface{}) (*gitlab.ListUsersOptions, int, error) {
+	if len(d) == 0 {
+		return nil, 0, nil
+	}
+
+	data := d[0].(map[string]interface{})
+	listUsersOptions := &gitlab.ListUsersOptions{}
+	options := ""
+
+	if orderBy := data["order_by"].(string); orderBy != "" {
+		listUsersOptions.OrderBy = &orderBy
+		options += orderBy
+	}
+	if sort := data["sort"].(string); sort != "" {
+		listUsersOptions.Sort = &sort
+		options += sort
+	}
+	if search := data["search"].(string); search != "" {
+		listUsersOptions.Search = &search
+		options += search
+	}
+	if active := data["active"].(bool); active != false {
+		listUsersOptions.Active = &active
+		options += strconv.FormatBool(active)
+	}
+	if blocked := data["blocked"].(bool); blocked != false {
+		listUsersOptions.Blocked = &blocked
+		options += strconv.FormatBool(blocked)
+	}
+	if externalUID := data["extern_uid"].(string); externalUID != "" {
+		listUsersOptions.ExternalUID = &externalUID
+		options += externalUID
+	}
+	if provider := data["provider"].(string); provider != "" {
+		// listUsersOptions.Provider = &provider
+		options += provider
+	}
+	if createdBefore := data["created_before"].(string); createdBefore != "" {
+		date, err := time.Parse("2006-01-02", createdBefore)
+		if err != nil {
+			return nil, 0, fmt.Errorf("created_before must be in yyyy-mm-dd format")
+		}
+		listUsersOptions.CreatedBefore = &date
+		options += createdBefore
+	}
+	if createdAfter := data["created_after"].(string); createdAfter != "" {
+		// date, err := time.Parse("2006-01-02", createdAfter)
+		// if err != nil {
+		// 	return nil, 0, fmt.Errorf("created_after must be in yyyy-mm-dd format")
+		// }
+		// listUsersOptions.CreatedAfter = &date
+		options += createdAfter
+	}
+
+	id := schema.HashString(options)
+
+	return listUsersOptions, id, nil
 }

--- a/gitlab/data_source_gitlab_users_test.go
+++ b/gitlab/data_source_gitlab_users_test.go
@@ -1,0 +1,27 @@
+package gitlab
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceGitlabUsers_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeLbIpRangesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.gitlab_users.test",
+						"users.#", regexp.MustCompile("^[1-9]*$"))),
+			},
+		},
+	})
+}
+
+const testAccComputeLbIpRangesConfig = `
+data "gitlab_users" "test" {}
+`

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -48,6 +48,9 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_deploy_key":   resourceGitlabDeployKey(),
 			"gitlab_user":         resourceGitlabUser(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"gitlab_users": dataSourceGitlabUsers(),
+		},
 
 		ConfigureFunc: providerConfigure,
 	}

--- a/vendor/github.com/xanzy/go-gitlab/README.md
+++ b/vendor/github.com/xanzy/go-gitlab/README.md
@@ -47,7 +47,7 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [x] Labels
 - [ ] License
 - [x] Merge Requests
-- [ ] Merge Request Approvals
+- [x] Merge Request Approvals
 - [x] Project Milestones
 - [ ] Group Milestones
 - [x] Namespaces

--- a/vendor/github.com/xanzy/go-gitlab/gitlab.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitlab.go
@@ -267,54 +267,55 @@ type Client struct {
 	UserAgent string
 
 	// Services used for talking to different parts of the GitLab API.
-	AwardEmoji           *AwardEmojiService
-	Branches             *BranchesService
-	BuildVariables       *BuildVariablesService
-	BroadcastMessage     *BroadcastMessagesService
-	Commits              *CommitsService
-	DeployKeys           *DeployKeysService
-	Deployments          *DeploymentsService
-	Environments         *EnvironmentsService
-	Events               *EventsService
-	Features             *FeaturesService
-	GitIgnoreTemplates   *GitIgnoreTemplatesService
-	Groups               *GroupsService
-	GroupMembers         *GroupMembersService
-	GroupMilestones      *GroupMilestonesService
-	Issues               *IssuesService
-	IssueLinks           *IssueLinksService
-	Jobs                 *JobsService
-	Boards               *IssueBoardsService
-	Labels               *LabelsService
-	MergeRequests        *MergeRequestsService
-	Milestones           *MilestonesService
-	Namespaces           *NamespacesService
-	Notes                *NotesService
-	NotificationSettings *NotificationSettingsService
-	PagesDomains         *PagesDomainsService
-	Pipelines            *PipelinesService
-	PipelineSchedules    *PipelineSchedulesService
-	PipelineTriggers     *PipelineTriggersService
-	Projects             *ProjectsService
-	ProjectMembers       *ProjectMembersService
-	ProjectSnippets      *ProjectSnippetsService
-	ProtectedBranches    *ProtectedBranchesService
-	Repositories         *RepositoriesService
-	RepositoryFiles      *RepositoryFilesService
-	Runners              *RunnersService
-	Search               *SearchService
-	Services             *ServicesService
-	Session              *SessionService
-	Settings             *SettingsService
-	Sidekiq              *SidekiqService
-	Snippets             *SnippetsService
-	SystemHooks          *SystemHooksService
-	Tags                 *TagsService
-	Todos                *TodosService
-	Users                *UsersService
-	Validate             *ValidateService
-	Version              *VersionService
-	Wikis                *WikisService
+	AwardEmoji            *AwardEmojiService
+	Branches              *BranchesService
+	BuildVariables        *BuildVariablesService
+	BroadcastMessage      *BroadcastMessagesService
+	Commits               *CommitsService
+	DeployKeys            *DeployKeysService
+	Deployments           *DeploymentsService
+	Environments          *EnvironmentsService
+	Events                *EventsService
+	Features              *FeaturesService
+	GitIgnoreTemplates    *GitIgnoreTemplatesService
+	Groups                *GroupsService
+	GroupMembers          *GroupMembersService
+	GroupMilestones       *GroupMilestonesService
+	Issues                *IssuesService
+	IssueLinks            *IssueLinksService
+	Jobs                  *JobsService
+	Boards                *IssueBoardsService
+	Labels                *LabelsService
+	MergeRequests         *MergeRequestsService
+	MergeRequestApprovals *MergeRequestApprovalsService
+	Milestones            *MilestonesService
+	Namespaces            *NamespacesService
+	Notes                 *NotesService
+	NotificationSettings  *NotificationSettingsService
+	PagesDomains          *PagesDomainsService
+	Pipelines             *PipelinesService
+	PipelineSchedules     *PipelineSchedulesService
+	PipelineTriggers      *PipelineTriggersService
+	Projects              *ProjectsService
+	ProjectMembers        *ProjectMembersService
+	ProjectSnippets       *ProjectSnippetsService
+	ProtectedBranches     *ProtectedBranchesService
+	Repositories          *RepositoriesService
+	RepositoryFiles       *RepositoryFilesService
+	Runners               *RunnersService
+	Search                *SearchService
+	Services              *ServicesService
+	Session               *SessionService
+	Settings              *SettingsService
+	Sidekiq               *SidekiqService
+	Snippets              *SnippetsService
+	SystemHooks           *SystemHooksService
+	Tags                  *TagsService
+	Todos                 *TodosService
+	Users                 *UsersService
+	Validate              *ValidateService
+	Version               *VersionService
+	Wikis                 *WikisService
 }
 
 // ListOptions specifies the optional parameters to various List methods that
@@ -376,6 +377,7 @@ func newClient(httpClient *http.Client, tokenType tokenType, token string) *Clie
 	c.Boards = &IssueBoardsService{client: c}
 	c.Labels = &LabelsService{client: c}
 	c.MergeRequests = &MergeRequestsService{client: c, timeStats: timeStats}
+	c.MergeRequestApprovals = &MergeRequestApprovalsService{client: c}
 	c.Milestones = &MilestonesService{client: c}
 	c.Namespaces = &NamespacesService{client: c}
 	c.Notes = &NotesService{client: c}

--- a/vendor/github.com/xanzy/go-gitlab/merge_request_approvals.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_request_approvals.go
@@ -1,0 +1,111 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// MergeRequestApprovalsService handles communication with the merge request
+// approvals related methods of the GitLab API. This includes reading/updating
+// approval settings and approve/unapproving merge requests
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/merge_request_approvals.html
+type MergeRequestApprovalsService struct {
+	client *Client
+}
+
+// MergeRequestApprovals represents GitLab merge request approvals.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#merge-request-level-mr-approvals
+type MergeRequestApprovals struct {
+	ID                int        `json:"id"`
+	ProjectID         int        `json:"project_id"`
+	Title             string     `json:"title"`
+	Description       string     `json:"description"`
+	State             string     `json:"state"`
+	CreatedAt         *time.Time `json:"created_at"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	MergeStatus       string     `json:"merge_status"`
+	ApprovalsRequired int        `json:"approvals_required"`
+	ApprovalsLeft     int        `json:"approvals_left"`
+	ApprovedBy        []struct {
+		User struct {
+			ID        int    `json:"id"`
+			Name      string `json:"name"`
+			Username  string `json:"username"`
+			State     string `json:"state"`
+			AvatarURL string `json:"avatar_url"`
+			WebURL    string `json:"web_url"`
+		} `json:"user"`
+	} `json:"approved_by"`
+	ApproverGroups []struct {
+		Group struct {
+			ID                   int    `json:"id"`
+			Name                 string `json:"name"`
+			Path                 string `json:"path"`
+			Description          string `json:"description"`
+			Visibility           string `json:"visibility"`
+			AvatarURL            string `json:"avatar_url"`
+			WebURL               string `json:"web_url"`
+			FullName             string `json:"full_name"`
+			FullPath             string `json:"full_path"`
+			LFSEnabled           bool   `json:"lfs_enabled"`
+			RequestAccessEnabled bool   `json:"request_access_enabled"`
+		} `json:"group"`
+	} `json:"approver_group"`
+}
+
+func (m MergeRequestApprovals) String() string {
+	return Stringify(m)
+}
+
+type ApproveMergeRequestOptions struct {
+	Sha *string `url:"sha,omitempty" json:"sha,omitempty"`
+}
+
+// ApproveMergeRequest approves a merge request on GitLab. If a non-empty sha
+// is provided then it must match the sha at the HEAD of the MR.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#approve-merge-request
+func (s *MergeRequestApprovalsService) ApproveMergeRequest(pid interface{}, mrID int, opt *ApproveMergeRequestOptions, options ...OptionFunc) (*MergeRequestApprovals, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approve", url.QueryEscape(project), mrID)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(MergeRequestApprovals)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// UnapproveMergeRequest unapproves a previously approved merge request on GitLab.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#unapprove-merge-request
+func (s *MergeRequestApprovalsService) UnapproveMergeRequest(pid interface{}, mr int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/unapprove", url.QueryEscape(project), mr)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/merge_requests.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_requests.go
@@ -111,37 +111,6 @@ func (m MergeRequest) String() string {
 	return Stringify(m)
 }
 
-// MergeRequestApprovals represents GitLab merge request approvals.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#merge-request-level-mr-approvals
-type MergeRequestApprovals struct {
-	ID                int        `json:"id"`
-	ProjectID         int        `json:"project_id"`
-	Title             string     `json:"title"`
-	Description       string     `json:"description"`
-	State             string     `json:"state"`
-	CreatedAt         *time.Time `json:"created_at"`
-	UpdatedAt         *time.Time `json:"updated_at"`
-	MergeStatus       string     `json:"merge_status"`
-	ApprovalsRequired int        `json:"approvals_required"`
-	ApprovalsLeft     int        `json:"approvals_left"`
-	ApprovedBy        []struct {
-		User struct {
-			Name      string `json:"name"`
-			Username  string `json:"username"`
-			ID        int    `json:"id"`
-			State     string `json:"state"`
-			AvatarURL string `json:"avatar_url"`
-			WebURL    string `json:"web_url"`
-		} `json:"user"`
-	} `json:"approved_by"`
-}
-
-func (m MergeRequestApprovals) String() string {
-	return Stringify(m)
-}
-
 // MergeRequestDiffVersion represents Gitlab merge request version.
 //
 // Gitlab API docs:

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -83,6 +83,8 @@ type ListUsersOptions struct {
 	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
 	ExternalUID   *string    `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
 	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty" `
+	OrderBy       *string    `url:"order_by,omitempty" json:order_by,omitempty`
+	Sort          *string    `url:"sort,omitempty" json:sort,omitempty`
 }
 
 // ListUsers gets a list of users.

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -82,9 +82,11 @@ type ListUsersOptions struct {
 	Search        *string    `url:"search,omitempty" json:"search,omitempty"`
 	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
 	ExternalUID   *string    `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
-	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty" `
-	OrderBy       *string    `url:"order_by,omitempty" json:order_by,omitempty`
-	Sort          *string    `url:"sort,omitempty" json:sort,omitempty`
+	Provider      *string    `url:"provider,omitempty" json:"provider,omitempty"`
+	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	OrderBy       *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort          *string    `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListUsers gets a list of users.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -585,10 +585,10 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "D0iQPrH+HJroZySGYYx4YTX0I5w=",
+			"checksumSHA1": "KFlR+HutofpLVJVziJSvfhT6+LU=",
 			"path": "github.com/xanzy/go-gitlab",
-			"revision": "3c94cb66a711296c1001cf7adba7943aa47b709a",
-			"revisionTime": "2018-04-27T09:56:23Z"
+			"revision": "108e358ee91157e0c1f561c9a90459f1ab58a0ef",
+			"revisionTime": "2018-05-07T13:52:37Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",


### PR DESCRIPTION
Add new gitlab_users resource that returns a list of users. It takes optional arguments:
- order_by
- sort
- search
- active
- blocked
- identities_extern_uid (must be set with provider)
- identities_provider (must be set with extern_uid)
- created_before
- created_after
- options

Examples:
* Get all users
```
data "gitlab_users" "all_users" {
}
```
* Get users created before the 5th of April 2018 ordered by username
```
data "gitlab_users" "username" {
    order_by = "username"
    created_before = "2018-04-05"
}
```