### PR TITLE
Add shared with groups option

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -104,11 +104,6 @@ func resourceGitlabProject() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								"guest", "reporter", "developer", "master"}, false),
 						},
-						"expires_at": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressDiffSharedWithGroupsExpiresAt(),
-						},
 						"group_name": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -310,7 +305,6 @@ func expandSharedWithGroupsOptions(d []interface{}) []*gitlab.ShareWithGroupOpti
 		shareWithGroupOptions := &gitlab.ShareWithGroupOptions{
 			GroupID:     gitlab.Int(data["group_id"].(int)),
 			GroupAccess: &groupAccess,
-			ExpiresAt:   gitlab.String(data["expires_at"].(string)),
 		}
 
 		shareWithGroupOptionsList = append(shareWithGroupOptionsList,
@@ -364,11 +358,4 @@ func updateSharedWithGroups(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-}
-
-func suppressDiffSharedWithGroupsExpiresAt() schema.SchemaDiffSuppressFunc {
-	return func(k, old, new string, d *schema.ResourceData) bool {
-		// API doesn't return expires_at parameter, so the diff should be removed
-		return true
-	}
 }

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -235,10 +235,9 @@ func resourceGitlabProjectDelete(d *schema.ResourceData, meta interface{}) error
 			if err != nil {
 				if response.StatusCode == 404 {
 					return out, "Deleted", nil
-				} else {
-					log.Printf("[ERROR] Received error: %#v", err)
-					return out, "Error", err
 				}
+				log.Printf("[ERROR] Received error: %#v", err)
+				return out, "Error", err
 			}
 			return out, "Deleting", nil
 		},

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -101,10 +101,13 @@ func resourceGitlabProject() *schema.Resource {
 						"group_access_level": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"guest", "reporter", "developer", "master"}, false),
 						},
 						"expires_at": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressDiffSharedWithGroupsExpiresAt(),
 						},
 						"group_name": {
 							Type:     schema.TypeString,
@@ -361,4 +364,11 @@ func updateSharedWithGroups(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func suppressDiffSharedWithGroupsExpiresAt() schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		// API doesn't return expires_at parameter, so the diff should be removed
+		return true
+	}
 }

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -344,7 +344,7 @@ func updateSharedWithGroups(d *schema.ResourceData, meta interface{}) error {
 	}
 	for _, group := range project.SharedWithGroups {
 		log.Printf("[DEBUG] update shared_with_group: unshare %v", group)
-		_, err := client.Projects.UnshareProjectFromGroup(d.Id(), group.GroupID)
+		_, err := client.Projects.DeleteSharedProjectFromGroup(d.Id(), group.GroupID)
 		if err != nil {
 			return err
 		}

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -300,7 +300,7 @@ func expandSharedWithGroupsOptions(d []interface{}) []*gitlab.ShareWithGroupOpti
 	for _, config := range d {
 		data := config.(map[string]interface{})
 
-		groupAccess := accessLevelID[data["group_access_level"].(string)]
+		groupAccess := accessLevelNameToValue[data["group_access_level"].(string)]
 
 		shareWithGroupOptions := &gitlab.ShareWithGroupOptions{
 			GroupID:     gitlab.Int(data["group_id"].(int)),
@@ -320,9 +320,10 @@ func flattenSharedWithGroupsOptions(project *gitlab.Project) []interface{} {
 
 	for _, option := range sharedWithGroups {
 		values := map[string]interface{}{
-			"group_id":           option.GroupID,
-			"group_access_level": accessLevel[gitlab.AccessLevelValue(option.GroupAccessLevel)],
-			"group_name":         option.GroupName,
+			"group_id": option.GroupID,
+			"group_access_level": accessLevelValueToName[gitlab.AccessLevelValue(
+				option.GroupAccessLevel)],
+			"group_name": option.GroupName,
 		}
 
 		sharedWithGroupsList = append(sharedWithGroupsList, values)

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -243,11 +243,12 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 		options.SnippetsEnabled = gitlab.Bool(d.Get("snippets_enabled").(bool))
 	}
 
-	log.Printf("[DEBUG] update gitlab project %s", d.Id())
-
-	_, _, err := client.Projects.EditProject(d.Id(), options)
-	if err != nil {
-		return err
+	if *options != (gitlab.EditProjectOptions{}) {
+		log.Printf("[DEBUG] update gitlab project %s", d.Id())
+		_, _, err := client.Projects.EditProject(d.Id(), options)
+		if err != nil {
+			return err
+		}
 	}
 
 	if d.HasChange("shared_with_groups") {

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -98,7 +98,7 @@ func resourceGitlabProject() *schema.Resource {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"group_access": {
+						"group_access_level": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -302,7 +302,7 @@ func expandSharedWithGroupsOptions(d []interface{}) []*gitlab.ShareWithGroupOpti
 	for _, config := range d {
 		data := config.(map[string]interface{})
 
-		groupAccess := accessLevelID[data["group_access"].(string)]
+		groupAccess := accessLevelID[data["group_access_level"].(string)]
 
 		shareWithGroupOptions := &gitlab.ShareWithGroupOptions{
 			GroupID:     gitlab.Int(data["group_id"].(int)),
@@ -323,9 +323,9 @@ func flattenSharedWithGroupsOptions(project *gitlab.Project) []interface{} {
 
 	for _, option := range sharedWithGroups {
 		values := map[string]interface{}{
-			"group_id":     option.GroupID,
-			"group_access": accessLevel[gitlab.AccessLevelValue(option.GroupAccessLevel)],
-			"group_name":   option.GroupName,
+			"group_id":           option.GroupID,
+			"group_access_level": accessLevel[gitlab.AccessLevelValue(option.GroupAccessLevel)],
+			"group_name":         option.GroupName,
 		}
 
 		sharedWithGroupsList = append(sharedWithGroupsList, values)

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -66,6 +66,72 @@ func TestAccGitlabProject_basic(t *testing.T) {
 					}),
 				),
 			},
+			//Update the project to share the project with a group
+			{
+				Config: testAccGitlabProjectSharedWithGroup(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
+					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
+						Name:                 fmt.Sprintf("foo-%d", rInt),
+						Path:                 fmt.Sprintf("foo.%d", rInt),
+						Description:          "Terraform acceptance tests",
+						IssuesEnabled:        true,
+						MergeRequestsEnabled: true,
+						WikiEnabled:          true,
+						SnippetsEnabled:      true,
+						Visibility:           gitlab.PublicVisibility,
+						SharedWithGroups: []struct {
+							GroupID          int
+							GroupName        string
+							GroupAccessLevel int
+						}{{0, "", 30}},
+					}),
+				),
+			},
+			//Update the project to share the project with more groups
+			{
+				Config: testAccGitlabProjectSharedWithGroup2(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
+					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
+						Name:                 fmt.Sprintf("foo-%d", rInt),
+						Path:                 fmt.Sprintf("foo.%d", rInt),
+						Description:          "Terraform acceptance tests",
+						IssuesEnabled:        true,
+						MergeRequestsEnabled: true,
+						WikiEnabled:          true,
+						SnippetsEnabled:      true,
+						Visibility:           gitlab.PublicVisibility,
+						SharedWithGroups: []struct {
+							GroupID          int
+							GroupName        string
+							GroupAccessLevel int
+						}{{0, "", 10}, {0, "", 30}},
+					}),
+				),
+			},
+			//Update the project to unshare the project from 1 group
+			{
+				Config: testAccGitlabProjectSharedWithGroup(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
+					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
+						Name:                 fmt.Sprintf("foo-%d", rInt),
+						Path:                 fmt.Sprintf("foo.%d", rInt),
+						Description:          "Terraform acceptance tests",
+						IssuesEnabled:        true,
+						MergeRequestsEnabled: true,
+						WikiEnabled:          true,
+						SnippetsEnabled:      true,
+						Visibility:           gitlab.PublicVisibility,
+						SharedWithGroups: []struct {
+							GroupID          int
+							GroupName        string
+							GroupAccessLevel int
+						}{{0, "", 30}},
+					}),
+				),
+			},
 		},
 	})
 }
@@ -142,6 +208,11 @@ type testAccGitlabProjectExpectedAttributes struct {
 	WikiEnabled          bool
 	SnippetsEnabled      bool
 	Visibility           gitlab.VisibilityValue
+	SharedWithGroups     []struct {
+		GroupID          int
+		GroupName        string
+		GroupAccessLevel int
+	}
 }
 
 func testAccCheckGitlabProjectAttributes(project *gitlab.Project, want *testAccGitlabProjectExpectedAttributes) resource.TestCheckFunc {
@@ -178,6 +249,12 @@ func testAccCheckGitlabProjectAttributes(project *gitlab.Project, want *testAccG
 
 		if project.Visibility != want.Visibility {
 			return fmt.Errorf("got visibility %q; want %q", project.Visibility, want.Visibility)
+		}
+
+		for i, group := range project.SharedWithGroups {
+			if group.GroupAccessLevel != want.SharedWithGroups[i].GroupAccessLevel {
+				return fmt.Errorf("got shared with groups access: %d; want %d", group.GroupAccessLevel, want.SharedWithGroups[i].GroupAccessLevel)
+			}
 		}
 
 		return nil
@@ -257,4 +334,65 @@ resource "gitlab_project" "foo" {
   snippets_enabled = false
 }
 	`, rInt, rInt)
+}
+
+func testAccGitlabProjectSharedWithGroup(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  path = "foo.%d"
+  description = "Terraform acceptance tests"
+  visibility_level = "public"
+
+  shared_with_groups = [
+    {
+		group_id           = "${gitlab_group.foo.id}"
+        group_access_level = "developer"
+    }
+  ]
+}
+
+resource "gitlab_group" "foo" {
+  name = "foo-name-%d"
+  path = "foo-path-%d"
+  description = "Terraform acceptance tests!"
+  visibility_level = "public"
+}
+	`, rInt, rInt, rInt, rInt)
+}
+
+func testAccGitlabProjectSharedWithGroup2(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  path = "foo.%d"
+  description = "Terraform acceptance tests"
+  visibility_level = "public"
+
+  shared_with_groups = [
+    {
+		group_id           = "${gitlab_group.foo.id}"
+        group_access_level = "guest"
+	},
+	{
+		group_id           = "${gitlab_group.foo2.id}"
+        group_access_level = "developer"
+    }
+  ]
+}
+
+resource "gitlab_group" "foo" {
+  name = "foo-name-%d"
+  path = "foo-path-%d"
+  description = "Terraform acceptance tests!"
+  visibility_level = "public"
+}
+
+resource "gitlab_group" "foo2" {
+	name = "foo2-name-%d"
+	path = "foo2-path-%d"
+	description = "Terraform acceptance tests!"
+	visibility_level = "public"
+  }
+	`, rInt, rInt, rInt, rInt, rInt, rInt)
 }

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -7,7 +7,7 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
-var accessLevelID = map[string]gitlab.AccessLevelValue{
+var accessLevelNameToValue = map[string]gitlab.AccessLevelValue{
 	"guest":     gitlab.GuestPermissions,
 	"reporter":  gitlab.ReporterPermissions,
 	"developer": gitlab.DeveloperPermissions,
@@ -15,7 +15,7 @@ var accessLevelID = map[string]gitlab.AccessLevelValue{
 	"owner":     gitlab.OwnerPermission,
 }
 
-var accessLevel = map[gitlab.AccessLevelValue]string{
+var accessLevelValueToName = map[gitlab.AccessLevelValue]string{
 	gitlab.GuestPermissions:     "guest",
 	gitlab.ReporterPermissions:  "reporter",
 	gitlab.DeveloperPermissions: "developer",

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -7,6 +7,22 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
+var accessLevelID = map[string]gitlab.AccessLevelValue{
+	"guest":     gitlab.GuestPermissions,
+	"reporter":  gitlab.ReporterPermissions,
+	"developer": gitlab.DeveloperPermissions,
+	"master":    gitlab.MasterPermissions,
+	"owner":     gitlab.OwnerPermission,
+}
+
+var accessLevel = map[gitlab.AccessLevelValue]string{
+	gitlab.GuestPermissions:     "guest",
+	gitlab.ReporterPermissions:  "reporter",
+	gitlab.DeveloperPermissions: "developer",
+	gitlab.MasterPermissions:    "master",
+	gitlab.OwnerPermission:      "owner",
+}
+
 // copied from ../github/util.go
 func validateValueFunc(values []string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (we []string, errors []error) {

--- a/vendor/github.com/xanzy/go-gitlab/README.md
+++ b/vendor/github.com/xanzy/go-gitlab/README.md
@@ -30,8 +30,11 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [x] Deployments
 - [x] Deploy Keys
 - [x] Environments
+- [ ] Epics
+- [ ] Epic Issues
 - [x] Events
 - [x] Feature flags
+- [ ] Geo Nodes
 - [x] Gitignores templates
 - [ ] GitLab CI Config templates
 - [x] Groups
@@ -42,19 +45,24 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [x] Jobs
 - [ ] Keys
 - [x] Labels
+- [ ] License
 - [x] Merge Requests
+- [ ] Merge Request Approvals
 - [x] Project Milestones
 - [ ] Group Milestones
 - [x] Namespaces
 - [x] Notes (comments)
+- [ ] Discussions (threaded comments)
 - [x] Notification settings
 - [ ] Open source license templates
-- [x] Page Domains
+- [x] Pages Domains
 - [x] Pipelines
 - [x] Pipeline Triggers
 - [x] Pipeline Schedules
 - [x] Projects (including setting Webhooks)
 - [ ] Project Access Requests
+- [ ] Project badges
+- [ ] Project import/export
 - [x] Project Members
 - [x] Project Snippets
 - [x] Protected Branches
@@ -122,7 +130,7 @@ func main() {
 		Description:          gitlab.String("Just a test project to play with"),
 		MergeRequestsEnabled: gitlab.Bool(true),
 		SnippetsEnabled:      gitlab.Bool(true),
-		Visibility:           gitlab.VisibilityLevel(gitlab.PublicVisibility),
+		Visibility:           gitlab.Visibility(gitlab.PublicVisibility),
 	}
 	project, _, err := git.Projects.CreateProject(p)
 	if err != nil {
@@ -130,11 +138,11 @@ func main() {
 	}
 
 	// Add a new snippet
-	s := &gitlab.CreateSnippetOptions{
+	s := &gitlab.CreateProjectSnippetOptions{
 		Title:           gitlab.String("Dummy Snippet"),
 		FileName:        gitlab.String("snippet.go"),
 		Code:            gitlab.String("package main...."),
-		Visibility:      gitlab.VisibilityLevel(gitlab.PublicVisibility),
+		Visibility:      gitlab.Visibility(gitlab.PublicVisibility),
 	}
 	_, _, err = git.ProjectSnippets.CreateSnippet(project.ID, s)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/merge_requests.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_requests.go
@@ -75,7 +75,15 @@ type MergeRequest struct {
 		State     string     `json:"state"`
 		CreatedAt *time.Time `json:"created_at"`
 	} `json:"merged_by"`
-	MergedAt                 *time.Time `json:"merged_at"`
+	MergedAt *time.Time `json:"merged_at"`
+	ClosedBy struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
+	} `json:"closed_by"`
+	ClosedAt                 *time.Time `json:"closed_at"`
 	Subscribed               bool       `json:"subscribed"`
 	SHA                      string     `json:"sha"`
 	MergeCommitSHA           string     `json:"merge_commit_sha"`
@@ -96,6 +104,7 @@ type MergeRequest struct {
 		DeletedFile bool   `json:"deleted_file"`
 	} `json:"changes"`
 	TimeStats *TimeStats `json:"time_stats"`
+	Squash    bool       `json:"squash"`
 }
 
 func (m MergeRequest) String() string {
@@ -105,7 +114,7 @@ func (m MergeRequest) String() string {
 // MergeRequestApprovals represents GitLab merge request approvals.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#merge-request-approvals
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#merge-request-level-mr-approvals
 type MergeRequestApprovals struct {
 	ID                int        `json:"id"`
 	ProjectID         int        `json:"project_id"`
@@ -116,7 +125,7 @@ type MergeRequestApprovals struct {
 	UpdatedAt         *time.Time `json:"updated_at"`
 	MergeStatus       string     `json:"merge_status"`
 	ApprovalsRequired int        `json:"approvals_required"`
-	ApprovalsMissing  int        `json:"approvals_missing"`
+	ApprovalsLeft     int        `json:"approvals_left"`
 	ApprovedBy        []struct {
 		User struct {
 			Name      string `json:"name"`
@@ -275,7 +284,7 @@ func (s *MergeRequestsService) GetMergeRequest(pid interface{}, mergeRequest int
 // GetMergeRequestApprovals gets information about a merge requests approvals
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#merge-request-approvals
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#merge-request-level-mr-approvals
 func (s *MergeRequestsService) GetMergeRequestApprovals(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequestApprovals, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/milestones.go
+++ b/vendor/github.com/xanzy/go-gitlab/milestones.go
@@ -184,6 +184,24 @@ func (s *MilestonesService) UpdateMilestone(pid interface{}, milestone int, opt 
 	return m, resp, err
 }
 
+// DeleteMilestone deletes a specified project milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/milestones.html#delete-project-milestone
+func (s *MilestonesService) DeleteMilestone(pid interface{}, milestone int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/milestones/%d", url.QueryEscape(project), milestone)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
 // GetMilestoneIssuesOptions represents the available GetMilestoneIssues() options.
 //
 // GitLab API docs:

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -646,6 +646,24 @@ func (s *ProjectsService) ShareProjectWithGroup(pid interface{}, opt *ShareWithG
 	return s.client.Do(req, nil)
 }
 
+// UnshareProjectFromGroup allows to unshare a project from a group.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#delete-a-shared-project-link-within-a-group
+func (s *ProjectsService) UnshareProjectFromGroup(pid interface{}, groupID int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/share/%d", url.QueryEscape(project), groupID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // ProjectMember represents a project member.
 //
 // GitLab API docs:

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -646,10 +646,10 @@ func (s *ProjectsService) ShareProjectWithGroup(pid interface{}, opt *ShareWithG
 	return s.client.Do(req, nil)
 }
 
-// UnshareProjectFromGroup allows to unshare a project from a group.
+// DeleteSharedProjectFromGroup allows to unshare a project from a group.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#delete-a-shared-project-link-within-a-group
-func (s *ProjectsService) UnshareProjectFromGroup(pid interface{}, groupID int, options ...OptionFunc) (*Response, error) {
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#delete-a-shared-project-link-within-a-group
+func (s *ProjectsService) DeleteSharedProjectFromGroup(pid interface{}, groupID int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/xanzy/go-gitlab/repositories.go
+++ b/vendor/github.com/xanzy/go-gitlab/repositories.go
@@ -50,6 +50,7 @@ func (t TreeNode) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repositories.html#list-repository-tree
 type ListTreeOptions struct {
+	ListOptions
 	Path      *string `url:"path,omitempty" json:"path,omitempty"`
 	Ref       *string `url:"ref,omitempty" json:"ref,omitempty"`
 	Recursive *bool   `url:"recursive,omitempty" json:"recursive,omitempty"`

--- a/vendor/github.com/xanzy/go-gitlab/tags.go
+++ b/vendor/github.com/xanzy/go-gitlab/tags.go
@@ -39,6 +39,9 @@ type Tag struct {
 	Message string   `json:"message"`
 }
 
+// Release represents a GitLab version release.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
 type Release struct {
 	TagName     string `json:"tag_name"`
 	Description string `json:"description"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -585,10 +585,10 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "NZk5D25Na3CA5FX1N0EgHfe/sSg=",
+			"checksumSHA1": "D0iQPrH+HJroZySGYYx4YTX0I5w=",
 			"path": "github.com/xanzy/go-gitlab",
-			"revision": "c00cef4b483bb262426d9b37bd252436dbccac55",
-			"revisionTime": "2018-04-06T12:10:38Z"
+			"revision": "3c94cb66a711296c1001cf7adba7943aa47b709a",
+			"revisionTime": "2018-04-27T09:56:23Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",


### PR DESCRIPTION
**Description**
Add shared_with_groups parameter to support sharing / unsharing projects with groups.

**Example**
```
resource "gitlab_group" "mygroup" {
  name = "mygroup"
  path = "mygroup"
}

resource "gitlab_project" "myproject" {
  name             = "myproject"
  visibility_level = "public"

  shared_with_groups = [
    {
      group_id     = "${gitlab_group.mygroup.id}"
      group_access = "developer"
      expires_at   = 2019-01-20
    }
}

```