### PR TITLE
Fix upstream rebase

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"gitlab_project": dataSourceGitlabProject(),
 			"gitlab_user":    dataSourceGitlabUser(),
+			"gitlab_users":   dataSourceGitlabUsers(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -55,10 +56,6 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_user":               resourceGitlabUser(),
 			"gitlab_project_membership": resourceGitlabProjectMembership(),
 			"gitlab_group_members":      resourceGitlabGroupMembers(),
-		},
-		DataSourcesMap: map[string]*schema.Resource{
-			"gitlab_users": dataSourceGitlabUsers(),
-			"gitlab_user":  dataSourceGitlabUser(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -32,4 +32,8 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GITLAB_TOKEN"); v == "" {
 		t.Fatal("GITLAB_TOKEN must be set for acceptance tests")
 	}
+
+	if v := os.Getenv("GITLAB_USER_ID"); v == "" {
+		t.Log("GITLAB_USER_ID must be set for group_members acceptance tests")
+	}
 }

--- a/gitlab/resource_gitlab_group_members.go
+++ b/gitlab/resource_gitlab_group_members.go
@@ -99,16 +99,8 @@ func resourceGitlabGroupMembersCreate(d *schema.ResourceData, meta interface{}) 
 	for _, groupMember := range groupMembers {
 		log.Printf("[DEBUG] create gitlab group member %d in %s", groupMember.UserID, groupID)
 
-		// Group owner is already existing and must be updated, not added
+		// Group owner exists and can't be updated
 		if groupOwnerID == *groupMember.UserID {
-			_, _, err := client.GroupMembers.EditGroupMember(groupID, *groupMember.UserID,
-				&gitlab.EditGroupMemberOptions{
-					AccessLevel: groupMember.AccessLevel,
-					ExpiresAt:   groupMember.ExpiresAt,
-				})
-			if err != nil {
-				return err
-			}
 			continue
 		}
 


### PR DESCRIPTION
**Description**

* Fix issue on `provider`: duplicated datasource
* Improve `group_members` resource and tests: add new GITLAB_USER_ID env variable to set group owner during tests and make the owner non updatable 