### PR TITLE
Update group_members: make group_owner_id required

### DIFF
--- a/gitlab/resource_gitlab_group_members.go
+++ b/gitlab/resource_gitlab_group_members.go
@@ -28,7 +28,7 @@ func resourceGitlabGroupMembers() *schema.Resource {
 			},
 			"group_owner_id": {
 				Type:     schema.TypeInt,
-				Optional: true,
+				Required: true,
 			},
 			"access_level": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
**Description**

* `group_owner_id` becomes required

When creating a new group, the group's creator will automatically be added to the group members. This parameter's role is to allow creating a group_members resource without having to import it first because of the already existing member (owner).

⚠️⚠️⚠️
This will require an **UPDATE** of all existing group_members resources without `group_owner_id` parameter.

**Recommendation**

When creating a group_members resource, owner should be the first list member.

```
resource "gitlab_group_members" "users" {
  group_id = "${gitlab_group.mygroup.id}"
  group_owner_id = "${local.users_ids["creator"]}"
  access_level = "owner"

  members = [
    {
      id = "${local.users_ids["creator"]}"
    },
    {
      id = "${local.users_ids["user2"]}"
    },
  ]
}
```

