### PR TITLE
Add support for impersonation tokens

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -77,6 +77,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_deploy_key_enable":          resourceGitlabDeployEnableKey(),
 			"gitlab_deploy_token":               resourceGitlabDeployToken(),
 			"gitlab_user":                       resourceGitlabUser(),
+			"gitlab_user_impersonation_token":   resourceGitlabUserImpersonationToken(),
 			"gitlab_project_membership":         resourceGitlabProjectMembership(),
 			"gitlab_group_membership":           resourceGitlabGroupMembership(),
 			"gitlab_project_variable":           resourceGitlabProjectVariable(),

--- a/gitlab/resource_gitlab_project_hook.go
+++ b/gitlab/resource_gitlab_project_hook.go
@@ -118,6 +118,7 @@ func resourceGitlabProjectHookRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
+
 	log.Printf("[DEBUG] read gitlab project hook %s/%d", project, hookId)
 
 	hook, _, err := client.Projects.GetProjectHook(project, hookId)

--- a/gitlab/resource_gitlab_project_hook.go
+++ b/gitlab/resource_gitlab_project_hook.go
@@ -118,7 +118,6 @@ func resourceGitlabProjectHookRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-
 	log.Printf("[DEBUG] read gitlab project hook %s/%d", project, hookId)
 
 	hook, _, err := client.Projects.GetProjectHook(project, hookId)

--- a/gitlab/resource_gitlab_user_impersonation_token.go
+++ b/gitlab/resource_gitlab_user_impersonation_token.go
@@ -115,11 +115,9 @@ func resourceGitlabUserImpersonationTokenRead(d *schema.ResourceData, meta inter
 	d.Set("name", impersonationToken.Name)
 	d.Set("active", impersonationToken.Active)
 	d.Set("revoked", impersonationToken.Revoked)
-	d.Set("token", impersonationToken.Token)
 	d.Set("scopes", impersonationToken.Scopes)
 	d.Set("created_at", impersonationToken.CreatedAt)
 	d.Set("expires_at", impersonationToken.ExpiresAt)
-
 	return nil
 }
 

--- a/gitlab/resource_gitlab_user_impersonation_token.go
+++ b/gitlab/resource_gitlab_user_impersonation_token.go
@@ -16,6 +16,9 @@ func resourceGitlabUserImpersonationToken() *schema.Resource {
 		Create: resourceGitlabUserImpersonationTokenCreate,
 		Read:   resourceGitlabUserImpersonationTokenRead,
 		Delete: resourceGitlabUserImpersonationTokenDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"user": {

--- a/gitlab/resource_gitlab_user_impersonation_token.go
+++ b/gitlab/resource_gitlab_user_impersonation_token.go
@@ -18,8 +18,8 @@ func resourceGitlabUserImpersonationToken() *schema.Resource {
 		Delete: resourceGitlabUserImpersonationTokenDelete,
 
 		Schema: map[string]*schema.Schema{
-			"user_i_idd": {
-				Type:     schema.TypeString,
+			"user": {
+				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
 			},
@@ -66,7 +66,7 @@ func resourceGitlabUserImpersonationToken() *schema.Resource {
 
 func resourceGitlabUserImpersonationTokenCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
-	user := d.Get("user_id").(int)
+	user := d.Get("user").(int)
 	options := &gitlab.CreateImpersonationTokenOptions{
 		Name: gitlab.String(d.Get("name").(string)),
 	}
@@ -94,7 +94,7 @@ func resourceGitlabUserImpersonationTokenCreate(d *schema.ResourceData, meta int
 
 func resourceGitlabUserImpersonationTokenRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
-	user := d.Get("user_id").(int)
+	user := d.Get("user").(int)
 	tokenId, err := strconv.Atoi(d.Id())
 
 	log.Printf("[DEBUG] read gitlab user impersonation token %d/%d", user, tokenId)
@@ -119,7 +119,7 @@ func resourceGitlabUserImpersonationTokenRead(d *schema.ResourceData, meta inter
 // so the object still exists on Gitlab side, but we remove it from TF state
 func resourceGitlabUserImpersonationTokenDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
-	user := d.Get("user_id").(int)
+	user := d.Get("user").(int)
 	tokenId, err := strconv.Atoi(d.Id())
 
 	log.Printf("[DEBUG] delete (revoke) gitlab user impersonation token %d/%d", user, tokenId)

--- a/gitlab/resource_gitlab_user_impersonation_token.go
+++ b/gitlab/resource_gitlab_user_impersonation_token.go
@@ -92,6 +92,8 @@ func resourceGitlabUserImpersonationTokenCreate(d *schema.ResourceData, meta int
 	}
 
 	d.SetId(fmt.Sprintf("%d/%d", user, impersonationToken.ID))
+	// We need to set token here instead of read, as it is only returned once
+	d.Set("token", impersonationToken.Token)
 
 	return resourceGitlabUserImpersonationTokenRead(d, meta)
 }
@@ -109,6 +111,7 @@ func resourceGitlabUserImpersonationTokenRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
+	d.Set("user", userId)
 	d.Set("name", impersonationToken.Name)
 	d.Set("active", impersonationToken.Active)
 	d.Set("revoked", impersonationToken.Revoked)

--- a/gitlab/resource_gitlab_user_impersonation_token.go
+++ b/gitlab/resource_gitlab_user_impersonation_token.go
@@ -18,7 +18,7 @@ func resourceGitlabUserImpersonationToken() *schema.Resource {
 		Delete: resourceGitlabUserImpersonationTokenDelete,
 
 		Schema: map[string]*schema.Schema{
-			"user": {
+			"user_i_idd": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,

--- a/gitlab/resource_gitlab_user_impersonation_token.go
+++ b/gitlab/resource_gitlab_user_impersonation_token.go
@@ -1,0 +1,129 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabUserImpersonationToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabUserImpersonationTokenCreate,
+		Read:   resourceGitlabUserImpersonationTokenRead,
+		Delete: resourceGitlabUserImpersonationTokenDelete,
+
+		Schema: map[string]*schema.Schema{
+			"user": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"active": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"revoked": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"token": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
+			},
+			"scopes": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"api", "read_user"}, true),
+				},
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expires_at": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGitlabUserImpersonationTokenCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	user := d.Get("user_id").(int)
+	options := &gitlab.CreateImpersonationTokenOptions{
+		Name: gitlab.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("scopes"); ok {
+		options.Scopes = stringSetToStringSlice(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("expires_at"); ok {
+		layout := "2006-01-02"
+		t, _ := time.Parse(layout, v.(string))
+		options.ExpiresAt = &t
+	}
+
+	log.Printf("[DEBUG] create gitlab user impersonation %s for user %d", *options.Name, user)
+	impersonationToken, _, err := client.Users.CreateImpersonationToken(user, options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%d", impersonationToken.ID))
+
+	return resourceGitlabUserImpersonationTokenRead(d, meta)
+}
+
+func resourceGitlabUserImpersonationTokenRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	user := d.Get("user_id").(int)
+	tokenId, err := strconv.Atoi(d.Id())
+
+	log.Printf("[DEBUG] read gitlab user impersonation token %d/%d", user, tokenId)
+
+	impersonationToken, _, err := client.Users.GetImpersonationToken(user, tokenId)
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", impersonationToken.Name)
+	d.Set("active", impersonationToken.Active)
+	d.Set("revoked", impersonationToken.Revoked)
+	d.Set("token", impersonationToken.Token)
+	d.Set("scopes", impersonationToken.Scopes)
+	d.Set("created_at", impersonationToken.CreatedAt)
+	d.Set("expires_at", impersonationToken.ExpiresAt)
+
+	return nil
+}
+
+// In case we delete an impersonation token, Gitlab will update it with `revoked: true`
+// so the object still exists on Gitlab side, but we remove it from TF state
+func resourceGitlabUserImpersonationTokenDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	user := d.Get("user_id").(int)
+	tokenId, err := strconv.Atoi(d.Id())
+
+	log.Printf("[DEBUG] delete (revoke) gitlab user impersonation token %d/%d", user, tokenId)
+
+	_, err = client.Users.RevokeImpersonationToken(user, tokenId)
+	return err
+}

--- a/gitlab/resource_gitlab_user_impersonation_token_test.go
+++ b/gitlab/resource_gitlab_user_impersonation_token_test.go
@@ -1,0 +1,195 @@
+package gitlab
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabUserImpersonationToken_basic(t *testing.T) {
+	var token gitlab.ImpersonationToken
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGitlabUserImpersonationTokenDestroy,
+		Steps: []resource.TestStep{
+			// Create a user and impersonation token
+			// gitlab_user is already tested as part of `resource_gitlab_user`
+			{
+				Config: testAccGitlabUserImpersonationTokenConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserImpersonationTokenExists("gitlab_user_impersonation_token.bar", &token),
+					testAccCheckGitlabUserImpersonationTokenAttributes(&token, &testAccCheckGitlabUserImpersonationTokenExpectedAttributes{
+						Name:    fmt.Sprintf("Token bar %d", rInt),
+						Active:  true,
+						Scopes:  []string{"api"},
+						Revoked: false,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabUserImpersonationToken_withexpiration(t *testing.T) {
+	var token gitlab.ImpersonationToken
+	rInt := acctest.RandInt()
+	layout := "2006-01-02"
+	d, _ := time.Parse(layout, "2222-12-31")
+	iso_d := gitlab.ISOTime(d)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGitlabUserImpersonationTokenDestroy,
+		Steps: []resource.TestStep{
+			// Create a user and impersonation token with expiration
+			// gitlab_user is already tested as part of `resource_gitlab_user`
+			{
+				Config: testAccGitlabUserImpersonationTokenWithExpirationConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserImpersonationTokenExists("gitlab_user_impersonation_token.will_expire", &token),
+					testAccCheckGitlabUserImpersonationTokenAttributes(&token, &testAccCheckGitlabUserImpersonationTokenExpectedAttributes{
+						Name:      fmt.Sprintf("Token will_expire %d", rInt),
+						Active:    true,
+						Scopes:    []string{"api", "read_user"},
+						Revoked:   false,
+						ExpiresAt: &iso_d,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabUserImpersonationTokenExists(n string, token *gitlab.ImpersonationToken) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		tokenID := rs.Primary.ID
+		if tokenID == "" {
+			return fmt.Errorf("No token ID is set")
+		}
+
+		userID := rs.Primary.Attributes["user_id"]
+		if userID == "" {
+			return fmt.Errorf("No user ID is set")
+		}
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		token_id, err := strconv.Atoi(tokenID)
+		user_id, err := strconv.Atoi(userID)
+		gotToken, _, err := conn.Users.GetImpersonationToken(user_id, token_id, nil)
+		if err != nil {
+			return err
+		}
+		*token = *gotToken
+		return nil
+	}
+}
+
+func testAccGitlabUserImpersonationTokenDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_user_impersonation_token" {
+			continue
+		}
+
+		userID := rs.Primary.Attributes["user_id"]
+
+		token_id, err := strconv.Atoi(rs.Primary.ID)
+		user_id, err := strconv.Atoi(userID)
+
+		token, resp, err := conn.Users.GetImpersonationToken(user_id, token_id, nil)
+		if err == nil {
+			if token != nil && fmt.Sprintf("%d", token.ID) == rs.Primary.ID && token.Revoked == false {
+				return fmt.Errorf("Impersonation token still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+type testAccCheckGitlabUserImpersonationTokenExpectedAttributes struct {
+	Name      string
+	Active    bool
+	Scopes    []string
+	Revoked   bool
+	ExpiresAt *gitlab.ISOTime
+}
+
+func testAccCheckGitlabUserImpersonationTokenAttributes(token *gitlab.ImpersonationToken, want *testAccCheckGitlabUserImpersonationTokenExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if token.Name != want.Name {
+			return fmt.Errorf("got name %q; want %q", token.Name, want.Name)
+		}
+
+		if token.Revoked != want.Revoked {
+			return fmt.Errorf("got revoked %t; want %t", token.Revoked, want.Revoked)
+		}
+
+		if token.ExpiresAt != want.ExpiresAt {
+			return fmt.Errorf("got revoked %q; want %q", token.ExpiresAt, want.ExpiresAt)
+		}
+
+		return nil
+	}
+}
+
+func testAccGitlabUserImpersonationTokenConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "foo %d"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "listest%d@ssss.com"
+  is_admin         = false
+  projects_limit   = 0
+  can_create_group = false
+  is_external      = false
+}
+
+resource "gitlab_user_impersonation_token" "bar" {
+    user = gitlab_user.foo.id
+    name = "Token bar %d"
+    scopes = ["api"]
+}
+  `, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccGitlabUserImpersonationTokenWithExpirationConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "foo %d"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "listest%d@ssss.com"
+  is_admin         = false
+  projects_limit   = 0
+  can_create_group = false
+  is_external      = false
+}
+
+resource "gitlab_user_impersonation_token" "will_expire" {
+    user = gitlab_user.foo.id
+    name = "Token will_expire %d"
+    scopes = ["api", "read_user"]
+    expires_at = "2222-12-31"
+}
+  `, rInt, rInt, rInt, rInt, rInt)
+}

--- a/gitlab/resource_gitlab_user_impersonation_token_test.go
+++ b/gitlab/resource_gitlab_user_impersonation_token_test.go
@@ -81,7 +81,7 @@ func testAccCheckGitlabUserImpersonationTokenExists(n string, token *gitlab.Impe
 			return fmt.Errorf("No token ID is set")
 		}
 
-		userID := rs.Primary.Attributes["user_id"]
+		userID := rs.Primary.Attributes["user"]
 		if userID == "" {
 			return fmt.Errorf("No user ID is set")
 		}
@@ -106,7 +106,7 @@ func testAccGitlabUserImpersonationTokenDestroy(s *terraform.State) error {
 			continue
 		}
 
-		userID := rs.Primary.Attributes["user_id"]
+		userID := rs.Primary.Attributes["user"]
 
 		token_id, err := strconv.Atoi(rs.Primary.ID)
 		user_id, err := strconv.Atoi(userID)
@@ -143,8 +143,8 @@ func testAccCheckGitlabUserImpersonationTokenAttributes(token *gitlab.Impersonat
 			return fmt.Errorf("got revoked %t; want %t", token.Revoked, want.Revoked)
 		}
 
-		if token.ExpiresAt != want.ExpiresAt {
-			return fmt.Errorf("got revoked %q; want %q", token.ExpiresAt, want.ExpiresAt)
+		if token.ExpiresAt.String() != want.ExpiresAt.String() {
+			return fmt.Errorf("got expires %q; want %q", token.ExpiresAt, want.ExpiresAt)
 		}
 
 		return nil

--- a/gitlab/resource_gitlab_user_impersonation_token_test.go
+++ b/gitlab/resource_gitlab_user_impersonation_token_test.go
@@ -143,8 +143,10 @@ func testAccCheckGitlabUserImpersonationTokenAttributes(token *gitlab.Impersonat
 			return fmt.Errorf("got revoked %t; want %t", token.Revoked, want.Revoked)
 		}
 
-		if token.ExpiresAt.String() != want.ExpiresAt.String() {
-			return fmt.Errorf("got expires %q; want %q", token.ExpiresAt, want.ExpiresAt)
+		if want.ExpiresAt != nil {
+			if token.ExpiresAt.String() != want.ExpiresAt.String() {
+				return fmt.Errorf("got expires %q; want %q", token.ExpiresAt, want.ExpiresAt)
+			}
 		}
 
 		return nil

--- a/website/docs/r/user_impersonation_token.html.markdown
+++ b/website/docs/r/user_impersonation_token.html.markdown
@@ -43,7 +43,7 @@ The resource exports the following attributes:
 * `id` The unique id given by the Gitlab server.
 * `active` (Boolean) Is the token active or expired
 * `revoked` (Boolean) Has the token been revoked
-* `created_ad` Time of token creation
+* `created_at` Time of token creation
 * `token` The impersonation token, will only be exported if resource has been created through terraform, but not in case of import.
 
 ## Importing user impersonation token

--- a/website/docs/r/user_impersonation_token.html.markdown
+++ b/website/docs/r/user_impersonation_token.html.markdown
@@ -44,3 +44,13 @@ The resource exports the following attributes:
 * `active` (Boolean) Is the token active or expired
 * `revoked` (Boolean) Has the token been revoked
 * `created_ad` Time of token creation
+* `token` The impersonation token, will only be exported if resource has been created through terraform, but not in case of import.
+
+## Importing user impersonation token
+
+You can import an impersonation token to terraform state using `terraform import <resource> <id>`.
+The `id` must be formated like `<user_id>/<token_id>`, for example:
+
+    terraform import gitlab_user_impersonation_token.example 21/25
+
+Note: When importing impersonation token, Gitlab do not send the token itself, so terraform won't be able to access it.

--- a/website/docs/r/user_impersonation_token.html.markdown
+++ b/website/docs/r/user_impersonation_token.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_user_impersonation_token"
+sidebar_current: "docs-gitlab-resource-user_impersonation_token"
+description: |-
+  Manage impersonation tokens for a user.
+---
+
+# gitlab\_user_impersonation_token
+
+This resource allows you to manage impersonation tokens of an existing user.
+
+## Example Usage
+
+```hcl
+resource "gitlab_user" "example" {
+  name     = "Example Foo"
+  username = "example"
+  password = "superPassword"
+  email    = "gitlab@user.create"
+}
+
+resource "gitlab_user_impersonation_token" "my-new-token" {
+    user   = gitlab_user.example.id
+    name   = "Token bar %d"
+    scopes = ["api"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `user` - (Required) The id of user
+* `name` - (Required) The name of the token
+* `scopes` - (Optional) Array, scopes of the token, can be any `api`, `user_read` or both.
+* `expires_at` - (Optional) Expiration date, format is `YYYY-MM-DD`
+
+## Attributes Reference
+
+The resource exports the following attributes:
+
+* `id` The unique id given by the Gitlab server.
+* `active` (Boolean) Is the token active or expired
+* `revoked` (Boolean) Has the token been revoked
+* `created_ad` Time of token creation


### PR DESCRIPTION
As there is no deletion in gitlab api, we do not update and use delete to revoke the token.

