### PR TITLE
Add users list external

### DIFF
--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -286,7 +286,7 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 	optionsHash.WriteString(",")
 	if data, ok := d.GetOk("external"); ok {
 		external := data.(bool)
-		listUsersOptions.external = &external
+		listUsersOptions.External = &external
 		optionsHash.WriteString(strconv.FormatBool(external))
 	}
 	optionsHash.WriteString(",")

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -41,6 +41,10 @@ func dataSourceGitlabUsers() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"external": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"extern_uid": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -278,6 +282,12 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 		blocked := data.(bool)
 		listUsersOptions.Blocked = &blocked
 		optionsHash.WriteString(strconv.FormatBool(blocked))
+	}
+	optionsHash.WriteString(",")
+	if data, ok := d.GetOk("external"); ok {
+		external := data.(bool)
+		listUsersOptions.external = &external
+		optionsHash.WriteString(strconv.FormatBool(external))
 	}
 	optionsHash.WriteString(",")
 	if data, ok := d.GetOk("extern_uid"); ok {

--- a/gitlab/data_source_gitlab_users_test.go
+++ b/gitlab/data_source_gitlab_users_test.go
@@ -49,12 +49,12 @@ func TestAccDataSourceGitlabUsers_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceGitlabExternalUsers(),
+				Config: testAccDataSourceGitlabExternalUsers(rInt),
 			},
 			{
-				Config: testAccDataSourceGitlabExternalUsersSearch(),
+				Config: testAccDataSourceGitlabExternalUsersSearch(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.gitlab_users.foo", "users.#", "49"),
+					resource.TestCheckResourceAttr("data.gitlab_users.only_external", "users.#", "10"),
 				),
 			},
 		},
@@ -151,23 +151,29 @@ data "gitlab_users" "foo" {
 	`, testAccDataSourceGitlabLotsOfUsers())
 }
 
-func testAccDataSourceGitlabExternalUsers() string {
+func testAccDataSourceGitlabExternalUsers(rInt int) string {
 	return fmt.Sprintf(`
-resource "gitlab_user" "foo" {
-  name             = format("lots user%%02d", count.index+1)
-  username         = format("user%%02d", count.index+1)
-  email            = format("user%%02d@example.com", count.index+1)
+resource "gitlab_user" "external" {
+  name             = format("ext user%%02d%d", count.index+1)
+  username         = format("ext%%02d%d", count.index+1)
+  email            = format("ext%%02d%d@example.com", count.index+1)
   password         = "8characters"
-  external         = ((count.index + 1) % 2 == 0)
-  count            = 99
+  is_external      = true
+  count            = 10
 }
-`)
+resource "gitlab_user" "internal" {
+  name             = format("int user%%02d%d", count.index+1)
+  username         = format("int%%02d%d", count.index+1)
+  email            = format("int%%02d%d@example.com", count.index+1)
+  password         = "8characters"
+  count            = 10
+}`, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
-func testAccDataSourceGitlabExternalUsersSearch() string {
+func testAccDataSourceGitlabExternalUsersSearch(rInt int) string {
 	return fmt.Sprintf(`%v
-data "gitlab_users" "foo" {
+data "gitlab_users" "only_external" {
 	external = true
 }
-	`, testAccDataSourceGitlabExternalUsers())
+	`, testAccDataSourceGitlabExternalUsers(rInt))
 }

--- a/gitlab/data_source_gitlab_users_test.go
+++ b/gitlab/data_source_gitlab_users_test.go
@@ -48,6 +48,15 @@ func TestAccDataSourceGitlabUsers_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.gitlab_users.foo", "users.#", "99"),
 				),
 			},
+			{
+				Config: testAccDataSourceGitlabExternalUsers(),
+			},
+			{
+				Config: testAccDataSourceGitlabExternalUsersSearch(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.gitlab_users.foo", "users.#", "49"),
+				),
+			},
 		},
 	})
 }
@@ -140,4 +149,25 @@ data "gitlab_users" "foo" {
 	search = "lots"
 }
 	`, testAccDataSourceGitlabLotsOfUsers())
+}
+
+func testAccDataSourceGitlabExternalUsers() string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = format("lots user%%02d", count.index+1)
+  username         = format("user%%02d", count.index+1)
+  email            = format("user%%02d@example.com", count.index+1)
+  password         = "8characters"
+  external         = ((count.index + 1) % 2 == 0)
+  count            = 99
+}
+`)
+}
+
+func testAccDataSourceGitlabExternalUsersSearch() string {
+	return fmt.Sprintf(`%v
+data "gitlab_users" "foo" {
+	external = true
+}
+	`, testAccDataSourceGitlabExternalUsers())
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-gitlab
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1
 	github.com/mitchellh/hashstructure v1.0.0
-	github.com/xanzy/go-gitlab v0.32.1
+	github.com/xanzy/go-gitlab v0.32.2-0.20200609074541-44a49f4b0a70
 )
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElyw
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/xanzy/go-gitlab v0.32.1 h1:eKGfAP2FWbqStD7DtGoRBb18IYwjuCxdtEVea2rNge4=
 github.com/xanzy/go-gitlab v0.32.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.32.2-0.20200609074541-44a49f4b0a70 h1:vC/RVA8QKNNmUAi2JQRiLlCmQwiAavSxysWAvMzSb+s=
+github.com/xanzy/go-gitlab v0.32.2-0.20200609074541-44a49f4b0a70/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=

--- a/vendor/github.com/xanzy/go-gitlab/groups.go
+++ b/vendor/github.com/xanzy/go-gitlab/groups.go
@@ -87,6 +87,7 @@ type ListGroupsOptions struct {
 	SkipGroups           []int             `url:"skip_groups,omitempty" json:"skip_groups,omitempty"`
 	Sort                 *string           `url:"sort,omitempty" json:"sort,omitempty"`
 	Statistics           *bool             `url:"statistics,omitempty" json:"statistics,omitempty"`
+	TopLevelOnly         *bool             `url:"top_level_only,omitempty" json:"top_level_only,omitempty"`
 	WithCustomAttributes *bool             `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -112,6 +112,7 @@ type ListUsersOptions struct {
 	CreatedAfter         *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	OrderBy              *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort                 *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	External             *bool      `url:"external,omitempty" json:"external,omitempty"`
 	WithCustomAttributes *bool      `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-gitlab v0.32.1
+# github.com/xanzy/go-gitlab v0.32.2-0.20200609074541-44a49f4b0a70
 ## explicit
 github.com/xanzy/go-gitlab
 # github.com/zclconf/go-cty v1.2.1

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -32,6 +32,8 @@ The following arguments are supported:
 
 * `blocked` - (Optional) Filter users that are blocked.
 
+* `external` - (Optional) Filter users that are external.
+
 * `order_by` - (Optional) Order the users' list by `id`, `name`, `username`, `created_at` or `updated_at`. (Requires administrator privileges)
 
 * `sort` - (Optional) Sort users' list in asc or desc order. (Requires administrator privileges)


### PR DESCRIPTION
This PR add  support for the `external` filter in `gitlab_user` datasource.

Is already working but set as WIP because it requires https://github.com/xanzy/go-gitlab/pull/869 which has not been released yet (hence the 2 commits, one for the code, one for the temporary update of `go-gitlab` mod)